### PR TITLE
No FileNotFoundException for log4j.properties 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,10 @@
 CHANGES
 
+1.0.1
+
+- fix clj1.3 regression for InstanceGroupConfig in emr.clj
+- avoid non-fatal FileNotFound error for lein compile when log4j.properties is not available
+
 1.0.0
 
 - Added lein version command

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,55 @@
+<project name="Lemur" default="package" basedir=".">
+
+  <macrodef name="lein">
+    <element name="lein-params" implicit="true"/>
+    <sequential>
+      <exec executable="lein" failonerror="yes"
+            dir="${basedir}">
+        <env key="JVM_OPTS" value="-Droot.logger=error,file,stdout"/>
+        <lein-params/>
+      </exec>
+    </sequential>
+  </macrodef>
+
+  <target name="jar">
+    <lein><arg value="jar"/></lein>
+  </target>
+
+  <target name="package" depends="jar">
+
+    <exec logError="true" executable="bash" outputproperty="jar-name">
+      <arg value="-c"/>
+      <arg value="ls lemur-*.jar"/>
+    </exec>
+
+    <fail message="Could not find lemur jar">
+      <condition><length string="${jar-name}" trim="true" length="0"/></condition>
+    </fail>
+    <echo message="jar ${jar-name}"/>
+
+    <exec logError="true" executable="sed" failonerror="true" inputstring="${jar-name}" outputproperty="jar-version">
+      <arg value="-e"/>
+      <arg value="s/lemur-\(.*\).jar/\1/"/>
+    </exec>
+    <echo message="jar ${jar-version}"/>
+
+    <tar destfile="${basedir}/tmp/releases/lemur-${jar-version}.tgz"
+         compression="gzip">
+      <tarfileset dir="${basedir}"
+                  prefix="/lemur-${jar-version}">
+        <include name="README.md"/>
+        <include name="project.clj"/>
+        <include name="lemur-*.jar"/>
+        <include name="lib/*.jar"/>
+        <include name="src/"/>
+        <include name="examples/"/>
+      </tarfileset>
+      <tarfileset dir="${basedir}"
+                  filemode="755"
+                  prefix="/lemur-${jar-version}">
+        <include name="bin/"/>
+      </tarfileset>
+    </tar>
+  </target>
+
+</project>

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,12 @@
-(defproject lemur "1.0.0"
+(defproject lemur "1.0.1"
 
   :description "Lemur is a tool to launch hadoop jobs locally or on EMR
                 based on a configuration file, referred to as a jobdef."
 
-  :jvm-opts ["-Dlog4j.configuration=file:resources/log4j.properties"]
+  :jvm-opts
+    ~(if (.exists (java.io.File. "resources/log4j.properties"))
+       ["-Dlog4j.configuration=file:resources/log4j.properties"]
+       [])
 
   :source-path "src/main/clj"
   :test-path "src/test/clj"


### PR DESCRIPTION
project.clj references resources/log4j.properties, so it was showing a FileNotFoundException when that file didn't exist.  This happens on "lein compile".  Reported by Steve Kim.
