### PR TITLE
Error check for no jobdef and better diag fr diff-test-data

### DIFF
--- a/src/main/clj/lemur/common.clj
+++ b/src/main/clj/lemur/common.clj
@@ -208,6 +208,7 @@
     cat, sort, diff
   Returns the result of sh/sh, which is a map."
   [left right]
+  (printf "Comparing sorted part files of %s to %s%n" left right)
   (let [[leftf rightf]
         (for [path [left right]]
           (let [file (File/createTempFile "diff-parts-" nil)
@@ -248,8 +249,6 @@
   with your system's sort and diff utilities."
   [& tests]
   (fn [eopts _]
-    (printf "Comparing expected (%s/expected) to results (%s)%n"
-            (:test-uri eopts) (:data-uri eopts))
     (doseq [[name path] tests]
       (quit-on-failure
         (diff-parts

--- a/src/main/clj/lemur/core.clj
+++ b/src/main/clj/lemur/core.clj
@@ -704,6 +704,9 @@ calls launch              - take action (upload files, start cluster, etc)
 
 (defn- execute-jobdef
   [file]
+  (when-not file
+    (quit :msg "No jobdef file was supplied" :exit-code 1
+          :cmdspec (context-get :command-spec)))
   (let [job-ns (gensym (-> file ccio/basename (s/replace #"\.clj$" "")))]
     (log/debug (str "Jobdef namespace " job-ns))
     (binding [*ns* (create-ns job-ns)]
@@ -724,9 +727,6 @@ calls launch              - take action (upload files, start cluster, etc)
       (use-base 'lemur.base)
       ; load the job file here... it is up to the job file to call fire! with
       ; the appropriate cluster and step(s)
-      (when-not file
-        (quit :msg "No jobdef file was supplied" :exit-code 1
-              :cmdspec (context-get :command-spec)))
       (log/info (str "Loading jobdef " file))
       (load-file file))))
 


### PR DESCRIPTION
Previously, it was throwing a non-obvious exception when the jobdef was
missing.  This is more helpful.

diff-test-data was only printing the parent of the dirs it was about
to test.  Now it prints that actual dirs that are being compared.
