### PR TITLE
add support for hbase-configure-site Bootstrap Action

### DIFF
--- a/src/main/clj/lemur/base.clj
+++ b/src/main/clj/lemur/base.clj
@@ -17,7 +17,7 @@
     lemur.core
     [lemur.common :only [val-opts]]
     [com.climate.services.aws.common :only [aws-credential-discovery]]
-    [lemur.bootstrap-actions :only [mk-hadoop-config]])
+    [lemur.bootstrap-actions :only [configure-hadoop]])
   (:require
     [clojure.tools.logging :as log]
     [lemur.util :as util]
@@ -77,11 +77,5 @@
     :data-uri "${base-uri}/data"
     :jar-uri "${base-uri}/jar"
 
-    :bootstrap-action.100
-      (fn [eopts]
-        (when-let [hc (seq (mk-hadoop-config eopts))]
-          ["Hadoop Config"
-           "s3://elasticmapreduce/bootstrap-actions/configure-hadoop"
-           hc]))
-
+    :bootstrap-action.100 configure-hadoop
     ))


### PR DESCRIPTION
take advantage of EMR's configure-hbase bootstrap action. using it
follows the same convention as the configure-hadoop bootstrap action.

See also: http://docs.amazonwebservices.com/ElasticMapReduce/latest/DeveloperGuide/emr-hbase-configure.html#emr-hbase-configure-site

fixes #8
