### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+/tmp


### PR DESCRIPTION
This pull request adds an ignore file that excludes the standard leiningen stuff as well as the output of the default build.xml target.
