### PR TITLE
Update sample-jobdef.clj to have the actual behavior of wait-on-step ref...

### DIFF
--- a/examples/sample-jobdef.clj
+++ b/examples/sample-jobdef.clj
@@ -340,5 +340,11 @@
 ;  :ready
 ;(wait <stage>)
 
-; If you want to block on step completion; if timeout is reached, it will stop and throw an exception.
+; If you want to block on step completion use wait-on-step as below;
+; returns a map with information on how the job completed.  If the timeout expires it might look like
+;    {:timeout true, :success false}
+; if the job completes before the timeout expires it might look like
+;    {:success true}
+; Read the function documentation for more details.
+;
 ;(wait-on-step step timeout-seconds)


### PR DESCRIPTION
...lected in the comments.

Fixed comment on the behaviour of wait-on-step.  The comments on the function in src/main/clj/lemur/core.clj are correct, but the statement about throwing exceptions that was here was not correct.
