### PR TITLE
Upgrade clojure dependency to 1.5.1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,10 +1,14 @@
 <project name="Lemur" default="package" basedir=".">
 
+  <!-- Define default for ${args} in the lein exec below. -->
+  <property name="args" value="" />
+
   <macrodef name="lein">
     <element name="lein-params" implicit="true"/>
     <sequential>
       <exec executable="lein2" failonerror="yes"
             dir="${basedir}">
+        <arg line="${args}"/>
         <env key="JVM_OPTS" value="-Droot.logger=error,file,stdout"/>
         <lein-params/>
       </exec>

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :source-paths ["src/main/clj"]
   :test-paths   ["src/test/clj"]
 
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/data.json "0.1.2"]
                  [bultitude "0.2.0"]
@@ -37,8 +37,9 @@
 
   :profiles {:dev {:plugins [[lein-midje "2.0.4"]]
                    :dependencies [[midje "1.4.0"]
-                                  [org.clojure/tools.trace "0.7.3"]
-                                  [clojure-source "1.3.0"]]}}
+                                  [org.clojure/tools.trace "0.7.3"]]}
+             :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
+             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
 
   :repl-init lemur.repl
   :main ^:skip-aot lemur.repl


### PR DESCRIPTION
Added profile declarations to project.clj so that you can do

```
lein with-profile +1.3 $TASK
lein with-profile +1.4 $TASK
```

to use an older version of Clojure.

Also modified the lein macro in build.xml so that ant can run leiningen
with arguments, like

```
ant package -Dargs="with-profile 1.3"
```
