### PR TITLE
Fix passthrough of binary options

### DIFF
--- a/src/main/clj/lemur/command_line.clj
+++ b/src/main/clj/lemur/command_line.clj
@@ -126,12 +126,12 @@
     (let [[options remaining look-for]
             (reduce (partial parse-args cmd-spec) [{} [] nil] args)]
       [(defaults-from-cmd-spec cmd-spec) options remaining look-for]))
-  ([cmd-spec [options remaining look-for] arg]
+  ([cmd-spec [options remaining look-for] orig-arg]
     ; Continue by processing one arg at a time
     (let [as-keyword #(->> % (re-find #"^--(.*)") second keyword)
-          option? (re-find #"^--" arg)
-          bang-option? (re-find #"^--no-(.*)$" arg)
-          arg (if bang-option? (str "--" (second bang-option?)) arg)
+          option? (re-find #"^--" orig-arg)
+          bang-option? (re-find #"^--no-(.*)$" orig-arg)
+          arg (if bang-option? (str "--" (second bang-option?)) orig-arg)
           find (fn [x] (seq (filter #(->> % first name (str "--") (= x)) cmd-spec)))
           in-cmd-spec? (find arg)
           boolean-in-cmd-spec? (find (str arg "?"))]
@@ -160,7 +160,7 @@
           [(assoc options (as-keyword (str arg "?")) true) remaining nil]
         ;not an option or not ours
         :else
-          [options (conj remaining arg) nil]))))
+          [options (conj remaining orig-arg) nil]))))
 
 (defn extract-cl-args
   "An alternate command line parser that takes an abbreviated cmd-spec. This is useful

--- a/src/test/clj/lemur/command_line_test.clj
+++ b/src/test/clj/lemur/command_line_test.clj
@@ -69,7 +69,15 @@
       (parse-args
         [[:foo "foo doc" "default1"] [:bar? "optional boolean" true]]
         ["--baz" "baz-val"])
-        => [{:bar? true :foo "default1"} {} ["--baz" "baz-val"] nil])))
+        => [{:bar? true :foo "default1"} {} ["--baz" "baz-val"] nil]
+
+      ;; Check passthrough
+      (parse-args
+        [] ["--bar"])
+        => [{} {} ["--bar"] nil]
+      (parse-args
+        [] ["--no-bar"])
+        => [{} {} ["--no-bar"] nil])))
 
 (deftest test-validate
   (let [eopts


### PR DESCRIPTION
Passthrough of binary options was broken so that the option "--no-bar"
would be passed on to the jar as "--bar", which is very incorrect! This
fixes lemur to pass on "--no-bar" correctly.
