### PR TITLE
Make 'lein test' run

### DIFF
--- a/src/test/clj/com/climate/services/aws/emr_test.clj
+++ b/src/test/clj/com/climate/services/aws/emr_test.clj
@@ -39,30 +39,33 @@
 (def bucket "lemur.unit.emr")
 (def test-flow-name "com.climate.services.aws.emr-test")
 
-(def aws-creds (awscommon/aws-credential-discovery))
+(def aws-creds (delay (awscommon/aws-credential-discovery)))
 
 (def ^:dynamic *flow-args*
-  {:bootstrap-actions
-   ; Only publicly available script, so we don't have to upload the others.
-   [(bootstrap "Hadoop Config"
-               "s3://elasticmapreduce/bootstrap-actions/configure-hadoop"
-               ["-m" "mapred.map.tasks.speculative.execution=false"])]
-   :log-uri (str "s3://" bucket)
-   :keypair (:keypair aws-creds) ; the elastic-mapreduce credentials.json file as a keypair entry
-   :ami-version "latest"
-   :num-instances 2
-   :master-type "m1.xlarge"
-   :slave-type "m1.xlarge"
-   :spot-task-type "m1.xlarge"
-   :spot-task-bid "1.00"
-   :spot-task-num 1
-   :keep-alive false})
+  (delay
+    {:bootstrap-actions
+     ; Only publicly available script, so we don't have to upload the others.
+     [(bootstrap "Hadoop Config"
+                 "s3://elasticmapreduce/bootstrap-actions/configure-hadoop"
+                 ["-m" "mapred.map.tasks.speculative.execution=false"])]
+     :log-uri (str "s3://" bucket)
+     :keypair (:keypair aws-creds) ; the elastic-mapreduce credentials.json file as a keypair entry
+     :ami-version "latest"
+     :num-instances 2
+     :master-type "m1.xlarge"
+     :slave-type "m1.xlarge"
+     :spot-task-type "m1.xlarge"
+     :spot-task-bid "1.00"
+     :spot-task-num 1
+     :keep-alive false}))
 
-(use-fixtures :once
-  (fn [f]
-    (binding [s3/*s3* (s3/s3 aws-creds)
-              *emr* (emr aws-creds)]
-      (f))))
+;; Use a macro instead of a fixture so non-integration tests can run without
+;; needing S3 credentials.
+(defmacro with-emr
+  [& body]
+  `(binding [s3/*s3* (s3/s3 @aws-creds)
+             *emr* (emr @aws-creds)]
+     ~@body))
 
 ;Starts a short-lived, 1 instance cluster. Has no bootstrap actions and no
 ;steps, so it will die right after starting up.
@@ -83,70 +86,76 @@
                "Try 'elastic-mapreduce --list' for an idea of where it's at.")
       (start-job-flow
         test-flow-name
+        "stream-step"
+        false
         [(step-config
-          "stream-step"
-          false
           "/home/hadoop/contrib/streaming/hadoop-streaming.jar"
           nil
           ["-input" (format "s3://%s/data/simple.txt" bucket)
            "-output" "/out"
            "-mapper" (format "s3://%s/scripts/wc.sh" bucket)])]
-       *flow-args*))))
+       @*flow-args*))))
 
 ; Specified as a fn rather than a test. This is a hack to force it to run before
 ; test-wait-on-step.  It will fail if the cluster has already COMPLETED.
 (defn test-flow-for-name-and-types []
-  (testing "emr/flow-for-name"
-    (let [jf (setup)]
-      (is (nil? (flow-for-name "non-existent")))
-      (is= jf (flow-id (flow-for-name test-flow-name)))))
-  (testing "non-default instance-types"
-    (let [jf (setup)
-          flow (flow-for-name test-flow-name)
-          instances (.getInstances flow)]
-      (is= "m1.xlarge" (.getMasterInstanceType instances))
-      (is= "m1.xlarge" (.getSlaveInstanceType instances)))))
+  (with-emr
+    (testing "emr/flow-for-name"
+      (let [jf (setup)]
+        (is (nil? (flow-for-name "non-existent")))
+        (is= jf (flow-id (flow-for-name test-flow-name)))))
+    (testing "non-default instance-types"
+      (let [jf (setup)
+            flow (flow-for-name test-flow-name)
+            instances (.getInstances flow)]
+        (is= "m1.xlarge" (.getMasterInstanceType instances))
+        (is= "m1.xlarge" (.getSlaveInstanceType instances))))))
 
 (deftest ^{:manual true} test-job-flow-detail
-  (testing "emr/job-flow-detail"
-    (let [jf (setup)
-          detail (job-flow-detail jf)]
-      (is (instance?
-            com.amazonaws.services.elasticmapreduce.model.JobFlowDetail
-            detail))
-      (is= jf (flow-id detail))
-      (is (instance? String (-> detail .getExecutionStatusDetail .getState))))))
+  (with-emr
+    (testing "emr/job-flow-detail"
+      (let [jf (setup)
+            detail (job-flow-detail jf)]
+        (is (instance?
+              com.amazonaws.services.elasticmapreduce.model.JobFlowDetail
+              detail))
+        (is= jf (flow-id detail))
+        (is (instance? String (-> detail .getExecutionStatusDetail .getState)))))))
 
 (deftest ^{:manual true} test-steps-for-jobflow
-  (testing "emr/steps-for-jobflow"
-    (let [jf (setup)
-          steps (steps-for-jobflow jf)]
-      (is= 1 (count steps))
-      (is= "stream-step" (-> steps first .getStepConfig .getName)))))
+  (with-emr
+    (testing "emr/steps-for-jobflow"
+      (let [jf (setup)
+            steps (steps-for-jobflow jf)]
+        (is= 1 (count steps))
+        (is= "stream-step" (-> steps first .getStepConfig .getName))))))
 
 (deftest ^{:manual true} test-step-detail
-  (testing "emr/step-detail"
-    (let [jf (setup)
-          sd (step-detail jf "stream-step")]
-      (is (instance? com.amazonaws.services.elasticmapreduce.model.StepDetail sd))
-      (is (nil? (step-detail jf "non-existant"))))))
+  (with-emr
+    (testing "emr/step-detail"
+      (let [jf (setup)
+            sd (step-detail jf "stream-step")]
+        (is (instance? com.amazonaws.services.elasticmapreduce.model.StepDetail sd))
+        (is (nil? (step-detail jf "non-existant")))))))
 
 (deftest ^{:manual true} test-step-status
-  (testing "emr/step-status"
-    (let [jf (setup)
-          state (step-status jf "stream-step")]
-      (is (contains? #{"PENDING" "RUNNING" "COMPLETED"} state)))))
+  (with-emr
+    (testing "emr/step-status"
+      (let [jf (setup)
+            state (step-status jf "stream-step")]
+        (is (contains? #{"PENDING" "RUNNING" "COMPLETED"} state))))))
 
 (deftest ^{:manual true} test-wait-on-step
-  (test-flow-for-name-and-types)  ;run the flow-for-name test before this one
-  (testing "emr/wait-on-step"
-    (let [jf (setup)
-          start-time (System/currentTimeMillis)
-          result (wait-on-step jf "stream-step" 600 20)
-          dur-millis (- (System/currentTimeMillis) start-time)]
-      (is (> dur-millis 2000)) ;will actually take several minutes -- mostly for EMR cluster startup
-      (is (map? result))
-      (is (:success result)))))
+  (with-emr
+    (test-flow-for-name-and-types)  ;run the flow-for-name test before this one
+    (testing "emr/wait-on-step"
+      (let [jf (setup)
+            start-time (System/currentTimeMillis)
+            result (wait-on-step jf "stream-step" 600 20)
+            dur-millis (- (System/currentTimeMillis) start-time)]
+        (is (> dur-millis 2000)) ;will actually take several minutes -- mostly for EMR cluster startup
+        (is (map? result))
+        (is (:success result))))))
 
 (deftest test-parse-spot-task-bid
   (let [parse-spot-task-bid (ns-resolve 'com.climate.services.aws.emr 'parse-spot-task-bid)]
@@ -157,14 +166,15 @@
         (ec2/demand-price "m1.xlarge") => 2.0 :times 1))))
 
 (deftest ^{:integration true} test-parse-spot-task-group
-  (is (nil? (parse-spot-task-group nil)))
-  (let [[spot-task-type spot-task-bid spot-task-num]
+  (with-emr
+    (is (nil? (parse-spot-task-group nil)))
+    (let [[spot-task-type spot-task-bid spot-task-num]
           (parse-spot-task-group "m1.xlarge,200%,20")
-        spread (- (ec2/demand-price "m1.xlarge") (ec2/reserve-price "m1.xlarge"))
-        expected-bid (+ (ec2/reserve-price "m1.xlarge") (* 2 spread))]
-    (is= "m1.xlarge" spot-task-type)
-    (is= 20 spot-task-num)
-    (is= (format "%.3f" expected-bid) spot-task-bid)))
+          spread (- (ec2/demand-price "m1.xlarge") (ec2/reserve-price "m1.xlarge"))
+          expected-bid (+ (ec2/reserve-price "m1.xlarge") (* 2 spread))]
+      (is= "m1.xlarge" spot-task-type)
+      (is= 20 spot-task-num)
+      (is= (format "%.3f" expected-bid) spot-task-bid))))
 
 (defn make-dummy-step []
   (doto (StepConfig.)
@@ -173,11 +183,15 @@
     (.setHadoopJarStep (.newEnableDebuggingStep (StepFactory.)))))
 
 (deftest ^{:manual true} test-add-steps-to-existing-flow
-  (testing "emr/add-step"
-    (binding [*flow-args* (conj *flow-args* {:keep-alive true})]
-      (let [jf-id (setup)
-            dummy-steps (make-dummy-step)]
-        (is= 0 (.size (steps-for-jobflow jf-id)))
-        (add-steps jf-id [dummy-steps])
-        (is= 1 (.size (steps-for-jobflow jf-id)))
-        (terminate-flow-id jf-id)))))
+  (with-emr
+    (testing "emr/add-step"
+      (binding [;; NOTE(lbarrett): Bind flow-args to an atom because we deref
+                ;; it when it's used because it's normally a delay (so we can
+                ;; run non-integration tests).
+                *flow-args* (atom (conj @*flow-args* {:keep-alive true}))]
+        (let [jf-id (setup)
+              dummy-steps (make-dummy-step)]
+          (is= 0 (.size (steps-for-jobflow jf-id)))
+          (add-steps jf-id [dummy-steps])
+          (is= 1 (.size (steps-for-jobflow jf-id)))
+          (terminate-flow-id jf-id))))))

--- a/src/test/clj/com/climate/services/aws/s3_test.clj
+++ b/src/test/clj/com/climate/services/aws/s3_test.clj
@@ -26,8 +26,12 @@
 
 (def test-bucket "lemur.unit.s3")
 
-(use-fixtures :once
-  (fn [f] (binding [*s3* (s3 (awscommon/aws-credential-discovery))] (f))))
+;; Use a macro instead of a fixture so non-integration tests can run without
+;; needing S3 credentials.
+(defmacro with-s3
+  [& body]
+  `(binding [*s3* (s3 (awscommon/aws-credential-discovery))]
+     ~@body))
 
 (deftest test-slash+derivitives
   (is= [false "foo/" "foo" false "/foo" "foo"]
@@ -55,52 +59,54 @@
   (is (not (s3path? (File. "")))))
 
 (deftest ^{:integration true} test-copy-object
-  (testing "s3/copy-object"
-    (with-bucket test-bucket  (fn []
-      (let [key-a "unit/copy-a.txt"
-            key-b "unit/copy-b.txt"]
-        (put-object-string test-bucket key-a "more string test data")
-        (is (not (object? test-bucket key-b)))
-        (copy-object test-bucket key-a test-bucket key-b)
-        (is (object? test-bucket key-b)))))))
+  (with-s3
+    (testing "s3/copy-object"
+      (with-bucket test-bucket  (fn []
+        (let [key-a "unit/copy-a.txt"
+              key-b "unit/copy-b.txt"]
+          (put-object-string test-bucket key-a "more string test data")
+          (is (not (object? test-bucket key-b)))
+          (copy-object test-bucket key-a test-bucket key-b)
+          (is (object? test-bucket key-b))))))))
 
 (deftest ^{:integration true} test-put-get-objects
-  (with-bucket test-bucket (fn []
-    (let [src-path "resources/log4j.properties"
-          dst-key-a "unit/object-a.txt"
-          dst-key-b "unit/object-b.txt"
-          test-data "string test data"
-          tmp-file (File/createTempFile "s3-unit" nil)]
-      (testing "s3/put-object"
-        ;; put-object-string
-        (is (not (object? test-bucket dst-key-a)))
-        (put-object-string test-bucket dst-key-a test-data)
-        (is (object? test-bucket dst-key-a))
-        ;; put-object-data
-        (is (not (object? test-bucket dst-key-b)))
-        (put-object-data test-bucket dst-key-b src-path)
-        (is (object? test-bucket dst-key-b)))
-      (testing "s3/get-object-data"
-        (is= test-data
-             (String. (get-object-data test-bucket dst-key-a) "UTF-8"))
-        ; download to a file
-        (is (get-object-data test-bucket dst-key-a tmp-file))
-        (is= (count test-data) (.length tmp-file))
-        ; download existing file w/ an etag (i.e. download should be skipped)
-        ; pass in a nil for s3, as further proof that the s3 service is not
-        ; called upon to take any action.
-        (is (false? (get-object-data test-bucket dst-key-a tmp-file
-                        (.getETag (object? test-bucket dst-key-a)))))
-        (is= (count test-data) (.length tmp-file))
-        (is (nil? (get-object-data test-bucket "no-such-key"))))
-      (testing "s3/objects"
-        ; recursive
-        (let [[obj-sum-1 obj-sum-2] (second (objects test-bucket nil nil))]
-          (is= "unit/object-a.txt" (.getKey obj-sum-1))
-          (is= "unit/object-b.txt" (.getKey obj-sum-2)))
-        ; default delimiter
-        (let [common-prefixes (first (objects test-bucket))]
-          (is= "unit/" (first common-prefixes))))))))
+  (with-s3
+    (with-bucket test-bucket (fn []
+      (let [src-path "resources/log4j.properties"
+            dst-key-a "unit/object-a.txt"
+            dst-key-b "unit/object-b.txt"
+            test-data "string test data"
+            tmp-file (File/createTempFile "s3-unit" nil)]
+        (testing "s3/put-object"
+          ;; put-object-string
+          (is (not (object? test-bucket dst-key-a)))
+          (put-object-string test-bucket dst-key-a test-data)
+          (is (object? test-bucket dst-key-a))
+          ;; put-object-data
+          (is (not (object? test-bucket dst-key-b)))
+          (put-object-data test-bucket dst-key-b src-path)
+          (is (object? test-bucket dst-key-b)))
+        (testing "s3/get-object-data"
+          (is= test-data
+               (String. (get-object-data test-bucket dst-key-a) "UTF-8"))
+          ; download to a file
+          (is (get-object-data test-bucket dst-key-a tmp-file))
+          (is= (count test-data) (.length tmp-file))
+          ; download existing file w/ an etag (i.e. download should be skipped)
+          ; pass in a nil for s3, as further proof that the s3 service is not
+          ; called upon to take any action.
+          (is (false? (get-object-data test-bucket dst-key-a tmp-file
+                          (.getETag (object? test-bucket dst-key-a)))))
+          (is= (count test-data) (.length tmp-file))
+          (is (nil? (get-object-data test-bucket "no-such-key"))))
+        (testing "s3/objects"
+          ; recursive
+          (let [[obj-sum-1 obj-sum-2] (second (objects test-bucket nil nil))]
+            (is= "unit/object-a.txt" (.getKey obj-sum-1))
+            (is= "unit/object-b.txt" (.getKey obj-sum-2)))
+          ; default delimiter
+          (let [common-prefixes (first (objects test-bucket))]
+            (is= "unit/" (first common-prefixes)))))))))
 
 (deftest test-parse-s3path
   (is= ["a.b" "c/d.txt"] (parse-s3path "s3://a.b/c/d.txt"))
@@ -123,65 +129,66 @@
     (is= (File. "/tmp/new-dir/b")    (new-s3-dest tmp-nd "d1/d2/" sample-full-key))))
 
 (deftest ^{:integration true} test-cp
-  (with-bucket test-bucket
-    (fn []
-      (let [dir (File. "src/test/resources")
-            s3p (partial s3path test-bucket)
-            tmp-dir (Files/createTempDir)
-            tmp-dir-src (.getPath tmp-dir)]
-        (testing "s3 upload"
-          ; directory upload
-          (cp dir (s3p "test-upload-dir"))
-          (is (object? test-bucket "test-upload-dir/sample.csv"))
-          (is (object? test-bucket "test-upload-dir/dates-file.txt"))
-          (cp dir (s3path test-bucket "test-upload-dir/"))
-          (is (object? test-bucket "test-upload-dir/resources/sample.csv"))
-          ; upload dir (str with no slash at the end) to dir
-          (cp "src/test/resources" (s3p "foo2/"))
-          (is (object? test-bucket "foo2/resources/sample.csv"))
-          ; upload dir (str with slash at the end) to dir
-          (cp "src/test/resources/" (s3p "foo3/"))
-          (is (object? test-bucket "foo3/sample.csv"))
-          ; upload file to file
-          (cp "src/test/resources/dates-file.txt" (s3p "foo/bar.txt"))
-          (is (object? test-bucket "foo/bar.txt"))
-          ; upload file to dir
-          (cp "src/test/resources/dates-file.txt" (s3p "foo/baz/"))
-          (is (object? test-bucket "foo/baz/dates-file.txt")))
-        (testing "s3 download"
-          (cp (s3p "foo/bar.txt") tmp-dir)
-          (is (.exists (File. tmp-dir "bar.txt")))
-          (cp (s3p "foo/bar.txt") (File. tmp-dir "bar2.txt"))
-          (is (.exists (File. tmp-dir "bar2.txt")))
-          (cp (s3p "foo/bar.txt") (str tmp-dir-src "/bar3.txt"))
-          (is (.exists (File. tmp-dir "bar3.txt")))
-          (cp (s3p "foo") (str tmp-dir-src "/new-dir"))
-          (is (.exists (File. tmp-dir "new-dir/foo/bar.txt")))
-          (is (.exists (File. tmp-dir "new-dir/foo/baz/dates-file.txt")))
-          (cp (s3p "foo/") (str tmp-dir-src "/new-dir2"))
-          (is (.exists (File. tmp-dir "new-dir2/bar.txt")))
-          (is (.exists (File. tmp-dir "new-dir2/baz/dates-file.txt")))
-          ; download existing, to test "sync" capability
-          (.delete (File. tmp-dir "new-dir2/bar.txt"))
-          (cp (s3p "foo/") (str tmp-dir-src "/new-dir2"))
-          (is (.exists (File. tmp-dir "new-dir2/bar.txt"))))
-        (testing "s3 copy within s3"
-          (cp (s3p "foo/bar.txt") (s3p "foo/newdir/"))
-          (is (object? test-bucket "foo/newdir/bar.txt"))
-          (cp (s3p "foo/bar.txt") (s3p "foo/newdir/bar4.txt"))
-          (is (object? test-bucket "foo/newdir/bar4.txt"))
-          (cp (s3p "foo/bar.txt") (s3p "/"))
-          ; same dest as prev, should overwrite, no error:
-          (cp (s3p "foo/bar.txt") (s3p ""))
-          (is (object? test-bucket "bar.txt"))
-          ; create a nested dir to test dir/dir copying
-          ; foo/baz/bar.txt
-          (cp (s3p "foo/bar.txt") (s3p "foo/baz/"))
-          (cp (s3p "foo/") (s3p "dest/"))
-          (is (object? test-bucket "dest/baz/bar.txt"))
-          (cp (s3p "foo") (s3p "dest1/"))
-          (is (object? test-bucket "dest1/foo/baz/bar.txt"))
-          (cp (s3p "foo/") (s3p "dest2"))
-          (is (object? test-bucket "dest2/baz/bar.txt"))
-          (cp (s3p "foo") (s3p "dest3"))
-          (is (object? test-bucket "dest3/baz/bar.txt")))))))
+  (with-s3
+    (with-bucket test-bucket
+      (fn []
+        (let [dir (File. "src/test/resources")
+              s3p (partial s3path test-bucket)
+              tmp-dir (Files/createTempDir)
+              tmp-dir-src (.getPath tmp-dir)]
+          (testing "s3 upload"
+            ; directory upload
+            (cp dir (s3p "test-upload-dir"))
+            (is (object? test-bucket "test-upload-dir/sample.csv"))
+            (is (object? test-bucket "test-upload-dir/dates-file.txt"))
+            (cp dir (s3path test-bucket "test-upload-dir/"))
+            (is (object? test-bucket "test-upload-dir/resources/sample.csv"))
+            ; upload dir (str with no slash at the end) to dir
+            (cp "src/test/resources" (s3p "foo2/"))
+            (is (object? test-bucket "foo2/resources/sample.csv"))
+            ; upload dir (str with slash at the end) to dir
+            (cp "src/test/resources/" (s3p "foo3/"))
+            (is (object? test-bucket "foo3/sample.csv"))
+            ; upload file to file
+            (cp "src/test/resources/dates-file.txt" (s3p "foo/bar.txt"))
+            (is (object? test-bucket "foo/bar.txt"))
+            ; upload file to dir
+            (cp "src/test/resources/dates-file.txt" (s3p "foo/baz/"))
+            (is (object? test-bucket "foo/baz/dates-file.txt")))
+          (testing "s3 download"
+            (cp (s3p "foo/bar.txt") tmp-dir)
+            (is (.exists (File. tmp-dir "bar.txt")))
+            (cp (s3p "foo/bar.txt") (File. tmp-dir "bar2.txt"))
+            (is (.exists (File. tmp-dir "bar2.txt")))
+            (cp (s3p "foo/bar.txt") (str tmp-dir-src "/bar3.txt"))
+            (is (.exists (File. tmp-dir "bar3.txt")))
+            (cp (s3p "foo") (str tmp-dir-src "/new-dir"))
+            (is (.exists (File. tmp-dir "new-dir/foo/bar.txt")))
+            (is (.exists (File. tmp-dir "new-dir/foo/baz/dates-file.txt")))
+            (cp (s3p "foo/") (str tmp-dir-src "/new-dir2"))
+            (is (.exists (File. tmp-dir "new-dir2/bar.txt")))
+            (is (.exists (File. tmp-dir "new-dir2/baz/dates-file.txt")))
+            ; download existing, to test "sync" capability
+            (.delete (File. tmp-dir "new-dir2/bar.txt"))
+            (cp (s3p "foo/") (str tmp-dir-src "/new-dir2"))
+            (is (.exists (File. tmp-dir "new-dir2/bar.txt"))))
+          (testing "s3 copy within s3"
+            (cp (s3p "foo/bar.txt") (s3p "foo/newdir/"))
+            (is (object? test-bucket "foo/newdir/bar.txt"))
+            (cp (s3p "foo/bar.txt") (s3p "foo/newdir/bar4.txt"))
+            (is (object? test-bucket "foo/newdir/bar4.txt"))
+            (cp (s3p "foo/bar.txt") (s3p "/"))
+            ; same dest as prev, should overwrite, no error:
+            (cp (s3p "foo/bar.txt") (s3p ""))
+            (is (object? test-bucket "bar.txt"))
+            ; create a nested dir to test dir/dir copying
+            ; foo/baz/bar.txt
+            (cp (s3p "foo/bar.txt") (s3p "foo/baz/"))
+            (cp (s3p "foo/") (s3p "dest/"))
+            (is (object? test-bucket "dest/baz/bar.txt"))
+            (cp (s3p "foo") (s3p "dest1/"))
+            (is (object? test-bucket "dest1/foo/baz/bar.txt"))
+            (cp (s3p "foo/") (s3p "dest2"))
+            (is (object? test-bucket "dest2/baz/bar.txt"))
+            (cp (s3p "foo") (s3p "dest3"))
+            (is (object? test-bucket "dest3/baz/bar.txt"))))))))


### PR DESCRIPTION
For me, running 'lein test' failed because it tried to set up some AWS
stuff, even for non-integration tests. This change should make the AWS
stuff only get set up for integration and manual tests.
