### PR TITLE
Avoid deprecated DescribeJobFlows API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,12 +16,14 @@
                  [org.clojure/data.json "0.1.2"]
                  [bultitude "0.2.0"]
 
-                 [com.amazonaws/aws-java-sdk "1.8.4"
-                  :exclusions [commons-codec]]
-                 [commons-codec "1.4"]
+                 [com.amazonaws/aws-java-sdk-emr "1.10.37"]
+                 [com.amazonaws/aws-java-sdk-s3 "1.10.37"]
+                 [com.amazonaws/aws-java-sdk-ec2 "1.10.37"]
+                 [commons-codec "1.10"]
+                 [org.apache.httpcomponents/httpclient "4.4.1"]
 
                  ; TODO these two are only to support hipchat-- isolate that functionality, so these libs can be optional
-                 [clj-http "0.1.3" :exclusions [commons-codec]]
+                 [clj-http "0.1.3" :exclusions [httpclient]]
                  [org.yaml/snakeyaml "1.7"]
 
                  ; TODO we should be able to consolidate on one or the other of these:

--- a/src/main/clj/com/climate/services/aws/emr.clj
+++ b/src/main/clj/com/climate/services/aws/emr.clj
@@ -13,16 +13,19 @@
       ActionOnFailure
       AddJobFlowStepsRequest
       BootstrapActionConfig
-      DescribeJobFlowsRequest
+      Cluster
+      DescribeClusterRequest
       HadoopJarStepConfig
       InstanceGroupConfig
       JobFlowInstancesConfig
       KeyValue
+      ListClustersRequest
+      ListStepsRequest
       PlacementType
       RunJobFlowRequest
       ScriptBootstrapActionConfig
       StepConfig
-      StepDetail
+      StepSummary
       Tag
       TerminateJobFlowsRequest]))
 
@@ -41,60 +44,59 @@
 
 (defn flow-id [flow] (if flow (.getJobFlowId flow)))
 
+(defn cluster-id [^Cluster cluster] (if cluster (.getId cluster)))
+
 (defn flow-name [flow] (if flow (.getName flow)))
 
-(defn flow-for-name [name]
-  (let [req (.withJobFlowStates (DescribeJobFlowsRequest.)
-                                (into-array ["RUNNING" "WAITING" "STARTING"]))
-        result (.describeJobFlows *emr* req)
-        flows (.getJobFlows result)
-        flows (filter #(= (flow-name %) name) flows)]
-    (first flows)))
+(defn cluster-name [^Cluster cluster] (if cluster (.getName cluster)))
 
-(defn job-flow-detail
-  "Get the JobFlowDetail."
+(defn cluster-for-id
+  "Get the Cluster for an id."
   [jobflow-id]
-  (->> [jobflow-id]
-       (DescribeJobFlowsRequest.)
-       (.describeJobFlows *emr*)
-       .getJobFlows
-       first))
+  (let [req (.withClusterId (DescribeClusterRequest.) jobflow-id)
+        result (.describeCluster *emr* req)]
+    (.getCluster result)))
 
 (defn jobflow-status
   "Return the state of the specified cluster."
   [jobflow-id]
-  (.. (job-flow-detail jobflow-id) getExecutionStatusDetail getState))
+  (.. (cluster-for-id jobflow-id) getStatus getState))
 
 (defn jobflow-master
   "Return the master public DNS name."
   [jobflow-id]
-  (.. (job-flow-detail jobflow-id) getInstances getMasterPublicDnsName))
+  (.. (cluster-for-id jobflow-id) getMasterPublicDnsName))
 
-(defn steps-for-jobflow [jobflow-id]
-  "Get the StepDetail objects for the given jobflow."
-  (-> jobflow-id
-      job-flow-detail
-      (#(if % (.getSteps %)))))
+(defn steps-for-jobflow [jobflow-id & [marker]]
+  "Get the StepSummary objects for the given jobflow."
+  (lazy-seq
+    (let [request (-> (ListStepsRequest.)
+                      (.withClusterId jobflow-id)
+                      (.withMarker marker))
+          result (.listSteps *emr* request)
+          newmark (.getMarker result)]
+      (concat (.getSteps result)
+              (when newmark (steps-for-jobflow jobflow-id newmark))))))
 
-(defn step-detail
-  "Returns the most recent StepDetail matching step-name."
+(defn step-summary-by-name
+  "Returns the most recent StepSummary matching step-name."
   [jobflow-id step-name]
   (log/debugf "Steps for %s, looking for %s in %s"
               jobflow-id step-name (steps-for-jobflow jobflow-id))
-  (first (filter #(->> % .getStepConfig .getName (= step-name))
+  (first (filter #(->> % .getName (= step-name))
                  (steps-for-jobflow jobflow-id))))
 
 (defn step-status
   "Get the status string for this step. One of PENDING, RUNNING,
   CONTINUE, COMPLETED, CANCELLED, FAILED, INTERRUPTED"
-  ([^StepDetail sd]
-    (when sd (.getState (.getExecutionStatusDetail sd))))
+  ([^StepSummary ss]
+    (when ss (.getState (.getStatus ss))))
   ([jobflow-id step-name]
-    (step-status (step-detail jobflow-id step-name))))
+    (step-status (step-summary-by-name jobflow-id step-name))))
 
 (defn- wait-on-step*
   [end-time jobflow-id step-name test-interval-seconds]
-  (let [sd (step-detail jobflow-id step-name)]
+  (let [sd (step-summary-by-name jobflow-id step-name)]
     (condp contains? (step-status sd)
       #{nil}
         {:success false}
@@ -102,8 +104,8 @@
         {:success true}
       #{"CONTINUE" "CANCELLED" "FAILED" "INTERRUPTED"}
         {:success false
-         :step-status-detail (.getExecutionStatusDetail sd)
-         :job-status-detail (.getExecutionStatusDetail (job-flow-detail jobflow-id))}
+         :step-status-detail (.getStatus sd)
+         :job-status-detail (.getStatus (cluster-for-id jobflow-id))}
       #{"PENDING" "RUNNING"}
         (if (< (System/currentTimeMillis) end-time)
           (do

--- a/src/test/clj/com/climate/shell_test.clj
+++ b/src/test/clj/com/climate/shell_test.clj
@@ -39,15 +39,17 @@
                   :env (merge-env {:FOO "bar"}))))))
 
 (deftest test-merge-env-2
-  (is (when-let [java-home (get (System/getenv) "JAVA_HOME")]
-        (.startsWith
-          (:out (sh "java" "-cp" (clj-main-jar) "clojure.main" "-e"
-                "(vector
-                   (get (System/getenv) \"JAVA_HOME\")
-                   (get (System/getenv) \"FOO\"))"
-                :err :pass
-                :env (merge-env {:FOO "bar"})))
-          (pr-str (vector java-home "bar"))))))
+  (let [java-home (get (System/getenv) "JAVA_HOME")]
+    (is java-home "set environment variable JAVA_HOME")
+    (is (when java-home
+          (.startsWith
+            (:out (sh "java" "-cp" (clj-main-jar) "clojure.main" "-e"
+                      "(vector
+                      (get (System/getenv) \"JAVA_HOME\")
+                      (get (System/getenv) \"FOO\"))"
+                      :err :pass
+                      :env (merge-env {:FOO "bar"})))
+            (pr-str (vector java-home "bar")))))))
 
 (deftest test-sh-with-files
   (let [txt "some test text"


### PR DESCRIPTION
Amazon has deprecated the DescribeJobFlows API, and soon they will disable it entirely.